### PR TITLE
添加内部资源重定向功能(test)

### DIFF
--- a/conanfile.txt
+++ b/conanfile.txt
@@ -3,6 +3,7 @@ cpprestsdk/2.10.18
 minizip/1.2.11
 zlib/1.2.12
 msgpack/3.3.0
+sqlite3/3.39.2
 
 [generators]
 premake

--- a/src/hook.cpp
+++ b/src/hook.cpp
@@ -900,10 +900,10 @@ namespace
 					il2cpp_string_new(newBundleFilePath.c_str())
 				);
 				if (!bundleFile) {
-					auto reGet = UmaDatabase::getBundleHandleTargetCache(std::wstring(newBundleFilePath.begin(), newBundleFilePath.end()));
+					auto reGet = UmaDatabase::getBundleHandleTargetCache(newAsseetData.first);
 					if (reGet != nullptr) {
 						bundleFile = reGet;
-						printf("Load failed but hit cache: %s\n", newBundleFilePath.c_str());
+						printf("Load failed but hit cache: %ls\n", newAsseetData.first.c_str());
 					}
 				}
 				if (bundleFile) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -575,10 +575,10 @@ namespace
 				}
 			}
 
-			if (document.HasMember("replaceBuiltInAssets")) {
+			if (document.HasMember("redirectBuiltInAssets")) {
 				g_enable_replaceBuiltInAssets = true;
 				g_replaceBuiltInAssets.clear();
-				for (auto& i : document["replaceBuiltInAssets"].GetObjectA()) {
+				for (auto& i : document["redirectBuiltInAssets"].GetObjectA()) {
 					g_replaceBuiltInAssets.emplace(i.name.GetString(), i.value.GetString());
 				}
 			}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -56,6 +56,8 @@ bool g_race_freecam_follow_umamusume = false;
 int g_race_freecam_follow_umamusume_index = -1;
 Vector3_t g_race_freecam_follow_umamusume_offset = {0, 10, -10};
 float g_race_freecam_follow_umamusume_distance = 0;
+std::map<std::string, std::string> g_replaceBuiltInAssets{};
+bool g_enable_replaceBuiltInAssets = false;
 
 std::string g_text_data_dict_path;
 std::string g_character_system_text_dict_path;
@@ -572,6 +574,17 @@ namespace
 					}
 				}
 			}
+
+			if (document.HasMember("replaceBuiltInAssets")) {
+				g_enable_replaceBuiltInAssets = true;
+				g_replaceBuiltInAssets.clear();
+				for (auto& i : document["replaceBuiltInAssets"].GetObjectA()) {
+					g_replaceBuiltInAssets.emplace(i.name.GetString(), i.value.GetString());
+				}
+			}
+			else {
+				g_enable_replaceBuiltInAssets = false;
+			}
 		}
 
 		config_stream.close();
@@ -796,6 +809,9 @@ namespace {
 			auto&& [storyDict, raceDict] = LoadStories();
 			auto&& [textData, characterSystemTextData, raceJikkyoCommentData, raceJikkyoMessageData] = LoadDicts();
 			local::reload_textdb(&dicts, std::move(staticDictCache), std::move(storyDict), std::move(raceDict), std::move(textData), std::move(characterSystemTextData), std::move(raceJikkyoCommentData), std::move(raceJikkyoMessageData));
+			if (g_enable_replaceBuiltInAssets) {
+				UmaDatabase::executeQueryRes();
+			}
 		}
 	}
 
@@ -1503,6 +1519,7 @@ int __stdcall DllMain(HINSTANCE dllModule, DWORD reason, LPVOID)
 			}
 
 			HttpServer::start_http_server(true);  // 启动HTTP服务器
+			UmaDatabase::executeQueryRes();
 
 			auto staticDictCache = ensure_latest_static_cache(g_static_dict_path);
 			if (g_dump_entries)

--- a/src/mhotkey.cpp
+++ b/src/mhotkey.cpp
@@ -20,6 +20,7 @@ namespace MHotkey{
         int tlgport = 43215;
 
         std::function<void(int, DWORD, DWORD, DWORD, DWORD, DWORD, DWORD, DWORD, DWORD)> mKeyBoardCallBack = nullptr;
+        bool hotKeyThreadStarted = false;
     }
 
     void SetKeyCallBack(std::function<void(int, DWORD, DWORD, DWORD, DWORD, DWORD, DWORD, DWORD, DWORD)> callbackfun) {
@@ -204,11 +205,14 @@ namespace MHotkey{
 
     int start_hotkey(char sethotk='u')
     {
+        MHotkey::hotk = sethotk;
+        if (hotKeyThreadStarted) return 1;
+
         HANDLE hThread;
         DWORD dwThread;
-        MHotkey::hotk = sethotk;
 
         hThread = CreateThread(NULL, NULL, (LPTHREAD_START_ROUTINE)my_HotKey, (LPVOID)"", NULL, &dwThread);
+        hotKeyThreadStarted = true;
 
         // ShowWindow(FindWindowA("ConsoleWindowClass", NULL), false);
         return 1;

--- a/src/stdinclude.hpp
+++ b/src/stdinclude.hpp
@@ -35,6 +35,7 @@
 #include "msgpack/msgpack.hpp"
 
 #include "camera/camera.hpp"
+#include "umadb/umadb.hpp"
 
 extern bool g_dump_entries;
 extern bool g_enable_logger;
@@ -96,3 +97,5 @@ extern bool g_race_freecam_follow_umamusume;
 extern float g_race_freecam_follow_umamusume_distance;
 extern Vector3_t g_race_freecam_follow_umamusume_offset;
 extern int g_race_freecam_follow_umamusume_index;
+extern std::map<std::string, std::string> g_replaceBuiltInAssets;
+extern bool g_enable_replaceBuiltInAssets;

--- a/src/umadb/umadb.cpp
+++ b/src/umadb/umadb.cpp
@@ -1,0 +1,246 @@
+#include <stdinclude.hpp>
+#include <sqlite3.h>
+#include <format>
+
+
+namespace UmaDatabase {
+    namespace {
+        void* AssetBundle_GetAllAssetNames = nullptr;
+        void* AssetBundle_LoadFromFile = nullptr;
+        void* AssetBundle_Unload = nullptr;
+        void* Object_IsNativeObjectAlive = nullptr;
+
+        const auto basePath = std::format("{}/AppData/LocalLow/Cygames/umamusume", getenv("UserProfile"));
+        std::unordered_map<std::string, std::string> umaFileAssetHash{};  // dbPath: bundleName
+        // std::unordered_map<std::string, std::list<std::wstring>> bundleNames{};  // dbName: [bundlePath1, bundlePath2, ...]
+        std::map<std::wstring, std::string> pathBundle{};  // bundlePath: bundleName
+        std::unordered_map<std::string, void*> bundleHandleTargetCache{};
+    }
+
+    void initPtr() {
+        AssetBundle_GetAllAssetNames = reinterpret_cast<void* (*)(void*)>(
+            il2cpp_symbols::get_method_pointer(
+                "UnityEngine.AssetBundleModule.dll", "UnityEngine",
+                "AssetBundle", "GetAllAssetNames", 0
+            )
+            );
+
+        AssetBundle_LoadFromFile = reinterpret_cast<void* (*)(Il2CppString*)>(
+            il2cpp_symbols::get_method_pointer(
+                "UnityEngine.AssetBundleModule.dll", "UnityEngine",
+                "AssetBundle", "LoadFromFile", 1
+            )
+            );
+
+        AssetBundle_Unload = reinterpret_cast<void(*)(void*, bool)>(
+            il2cpp_symbols::get_method_pointer(
+                "UnityEngine.AssetBundleModule.dll", "UnityEngine",
+                "AssetBundle", "Unload", -1
+            )
+            );
+
+        Object_IsNativeObjectAlive = reinterpret_cast<bool(*)(void*)>(
+            il2cpp_symbols::get_method_pointer(
+                "UnityEngine.CoreModule.dll", "UnityEngine", "Object", "IsNativeObjectAlive", 1
+            )
+            );
+    }
+
+    bool pathIsMatch(std::wstring bundlePath, std::string dbPath) {
+        std::wstring dbPathW(dbPath.begin(), dbPath.end());
+        return bundlePath.find(dbPathW) != -1;
+    }
+
+    std::wstring dbPathToBundlePath(std::string dbPath) {
+        for (auto& i : pathBundle) {
+            if (pathIsMatch(i.first, dbPath)) {
+                return i.first;
+            }
+        }
+        return L"";
+    }
+
+    void setBundleHandleTargetCache(std::wstring bundlePath, void* target) {
+        if (pathBundle.find(bundlePath) == pathBundle.end()) {
+            printf("setBundleHandleTargetCache: %ls not found\n", bundlePath.c_str());
+            return;
+        }
+
+        auto bundleName = pathBundle.at(bundlePath);
+        // printf("set bundle: %s cache at %p", bundleName.c_str(), target);
+        bundleHandleTargetCache.emplace(bundleName, target);
+    }
+
+    void* getBundleHandleTargetCache(std::wstring bundlePath, bool isDbPath) {
+        if (Object_IsNativeObjectAlive == nullptr) {
+            initPtr();
+        }
+
+        std::string bundleName;
+        
+        if (isDbPath) {
+            const auto newBundlePath = dbPathToBundlePath(std::string(bundlePath.begin(), bundlePath.end()));
+            if (newBundlePath.empty()) {
+                return nullptr;
+            }
+
+            if (pathBundle.find(newBundlePath) == pathBundle.end()) {
+                // printf("getBundleHandleTargetCache: %ls not found\n", bundlePath.c_str());
+                return nullptr;
+            }
+            bundleName = pathBundle.at(newBundlePath);
+        }
+        else {
+            if (pathBundle.find(bundlePath) == pathBundle.end()) {
+                // printf("getBundleHandleTargetCache: %ls not found\n", bundlePath.c_str());
+                return nullptr;
+            }
+            bundleName = pathBundle.at(bundlePath);
+        }
+        
+
+        printf("searchBundleName: %s\n", bundleName.c_str());
+
+        if (bundleHandleTargetCache.find(bundleName) == bundleHandleTargetCache.end()) {
+            printf("getBundleHandleTargetCache: Bundle %s not found\n", bundleName.c_str());
+            return nullptr;
+        }
+        auto ret = bundleHandleTargetCache.at(bundleName);
+        if (!reinterpret_cast<bool(*)(void*)>(Object_IsNativeObjectAlive)(ret)) {
+            printf("bundle: %s death\n", bundleName.c_str());
+            bundleHandleTargetCache.erase(bundleName);
+            return nullptr;
+        }
+        return ret;
+    }
+
+    std::unordered_map<std::string, std::string>* getUmaFileAssetHash() {
+        return &umaFileAssetHash;
+    }
+
+    std::string bundleNameToPath(std::string bundleName) {
+        return std::format("{}/dat/{}/{}", basePath, bundleName.substr(0, 2), bundleName);
+        /*
+        const auto origPath = std::format("{}/dat/{}/{}", basePath, bundleName.substr(0, 2), bundleName);
+        const auto newPath = std::format("./RedirectAsset/{}", bundleName);
+        if (!std::filesystem::is_directory("./RedirectAsset")) {
+            std::filesystem::create_directory("./RedirectAsset");
+        }
+        std::filesystem::copy_file(origPath, newPath, std::filesystem::copy_options::overwrite_existing);
+        return newPath;
+        */
+    }
+
+    /*
+    bundle内路径, bundle整体本地路径
+    */
+    std::pair<std::wstring, std::string> origPathToNewPath(std::wstring origPath) {
+        std::string newDbPath;
+        std::string newBundleName;
+        for (auto& i : g_replaceBuiltInAssets) {
+            if (pathIsMatch(origPath, i.first)) {
+                newDbPath = i.second;
+                if (umaFileAssetHash.find(newDbPath) == umaFileAssetHash.end()) {
+                    printf("dbPath: %s not found.", newDbPath.c_str());
+                    continue;
+                }
+                newBundleName = umaFileAssetHash.at(newDbPath);
+                break;
+            }
+        }
+        if (newDbPath.empty()) {
+            return std::make_pair(L"", "");
+        }
+        auto newBundlePath = dbPathToBundlePath(newDbPath);
+        if (newBundlePath.empty()) {
+            return std::make_pair(L"", "");
+        }
+        return std::make_pair(newBundlePath, newBundleName);
+    }
+
+    void initBundleAllNames(std::string bundleName) {
+        if ((AssetBundle_LoadFromFile == nullptr) || (AssetBundle_GetAllAssetNames == nullptr)) {
+            // printf("ptr is null\n");
+            initPtr();
+        }
+        const auto bundleFile = reinterpret_cast<void* (*)(Il2CppString*)>(AssetBundle_LoadFromFile)(
+            il2cpp_string_new(bundleName.c_str())
+        );
+        if (!bundleFile) {
+            printf("init bundle failed: %s\n", bundleName.c_str());
+            return;
+        }
+        const auto allAssetPaths = reinterpret_cast<void* (*)(void*)>(AssetBundle_GetAllAssetNames)(bundleFile);
+        il2cpp_symbols::iterate_IEnumerable<Il2CppString*>(allAssetPaths, [bundleName](Il2CppString* path)
+            {
+                pathBundle.emplace(path->start_char, bundleName);
+                /*
+                if (bundleNames.find(bundleName) == bundleNames.end()) {
+                    bundleNames.emplace(bundleName, std::list<std::wstring>{path->start_char});
+                }
+                else {
+                    auto& lst = bundleNames.at(bundleName);
+                    lst.emplace_back(path->start_char);
+                }
+                */
+            }
+        );
+
+        auto assetBundleHandle = il2cpp_gchandle_new(bundleFile, false);
+        reinterpret_cast<void(*)(void*, bool)>(AssetBundle_Unload)(il2cpp_gchandle_get_target(assetBundleHandle), true); 
+    }
+
+    void executeQueryRes()
+    {
+        sqlite3* db;
+        char* zErrMsg = 0;
+        const char* data = "Getting Resource Hash...";
+        
+        const auto dbPath = std::format("{}/meta", basePath);
+        int rc = sqlite3_open(dbPath.c_str(), &db);
+        if (rc) {
+            printf("Can't open database: %s\n", sqlite3_errmsg(db));
+            return;
+        }
+        umaFileAssetHash.clear();
+        // bundleNames.clear();
+        pathBundle.clear();
+
+        for (auto& i : g_replaceBuiltInAssets) {
+            for (int _n = 0; _n <= 1; _n++) {
+                const char* queryPath = (_n ? i.second.c_str() : i.first.c_str());
+
+                auto sql = sqlite3_mprintf("SELECT h FROM a WHERE n=%Q", queryPath);
+
+                char** pResult;
+                char* errmsg;
+                int nRow;
+                int nCol;
+
+                // rc = sqlite3_exec(db, sql, callback, (void*)data, &zErrMsg);
+                rc = sqlite3_get_table(db, sql, &pResult, &nRow, &nCol, &zErrMsg);
+                sqlite3_free(sql);
+                if (rc != SQLITE_OK) {
+                    printf("SQL error: %s\n", zErrMsg);
+                    sqlite3_free(zErrMsg);
+                    continue;
+                }
+
+                for (int n = 0; n < nRow; n++)
+                {
+                    for (int j = 0; j < nCol; j++)
+                    {
+                        // auto key = pResult[j];
+                        auto value = pResult[nCol];
+                        initBundleAllNames(bundleNameToPath(value));
+                        printf("FindAsset: %s, At: %s\n", queryPath, value);
+                        umaFileAssetHash.emplace(queryPath, value);
+                    }
+                }
+                printf("Row: %d, Col: %d\n", nRow, nCol);
+                sqlite3_free_table(pResult);
+            }
+        }
+        sqlite3_close(db);
+    }
+}

--- a/src/umadb/umadb.hpp
+++ b/src/umadb/umadb.hpp
@@ -1,0 +1,12 @@
+#pragma once
+#include <unordered_map>
+
+namespace UmaDatabase {
+	std::unordered_map<std::string, std::string>* getUmaFileAssetHash();
+	void executeQueryRes();
+	std::string bundleNameToPath(std::string bundleName);
+	std::pair<std::wstring, std::string> origPathToNewPath(std::wstring origPath);
+
+	void setBundleHandleTargetCache(std::wstring bundlePath, void* target);
+	void* getBundleHandleTargetCache(std::wstring bundlePath, bool isDbPath=false);
+}


### PR DESCRIPTION
 - 修复部分情况下抗锯齿设置不生效的bug (虽然肉眼基本上看不出来区别
 - 资源重定向功能配置例:
```json
{
    "redirectBuiltInAssets": {
        "源文件路径": "需要替换的资源路径"
    }
}
```
 - 文件路径需要填写 `%UserProfile%\AppData\LocalLow\Cygames\umamusume\meta` 数据库内 `a` 表的 `n` 列内容。此文件为`sqlite`数据库, 可以使用任意数据库管理软件打开。
 - 当您进行下图所示的设置后, 您的主界面Logo图标将被替换。 更多用处请自行探索~
![image](https://user-images.githubusercontent.com/74499927/190896637-436660c9-000a-433c-899b-3028d55ef198.png)
![image](https://user-images.githubusercontent.com/74499927/190896958-148e31b4-17ec-48b3-81a7-f38049f1aab5.png)
