### PR TITLE
Update readme_EN.md

### DIFF
--- a/readme_EN.md
+++ b/readme_EN.md
@@ -6,14 +6,14 @@
 [![Download](https://img.shields.io/github/v/release/MinamiChiwa/umamusume-localify-zh-CN?color=orange&logoColor=red&label=Download&logo=DocuSign)](https://github.com/MinamiChiwa/Trainers-Legend-G/releases/latest)
 [![Discord](https://img.shields.io/discord/973208860217200653?color=orange&label=Discord&logo=Discord&logoColor=red)](https://discord.com/invite/TBCSv5hU69)
 
-[Simplified Chinese](https://github.com/MinamiChiwa/Trainers-Legend-G) | [Traditional Chinese (Taiwan)](https://github.com/yotv2000tw/Trainers-Legend-G-TRANS-zh-tw/) | English
+[Simplified Chinese](https://github.com/MinamiChiwa/Trainers-Legend-G) | [Traditional Chinese](https://github.com/yotv2000tw/Trainers-Legend-G-TRANS-zh-tw/) | English
 
 </div>
 
 
 # Introduction
 
-- This plugin can give Umamusume Pretty Derby (DMM Client) players from Mainland China a better experience. There's also a folk of [Traditional Chinese (Taiwan) version](https://github.com/yotv2000tw/Trainers-Legend-G-TRANS-zh-tw) .
+- This plugin can give Umamusume Pretty Derby (DMM Client) players from Mainland China a better experience. There's also a folk of [Traditional Chinese version](https://github.com/yotv2000tw/Trainers-Legend-G-TRANS-zh-tw) .
 - The plugin is forked from [`umamusume-localify`](https://github.com/GEEKiDoS/umamusume-localify) by @GEEKiDoS.
 
 


### PR DESCRIPTION
For the sake of simplicity, delete "(Taiwan)" from "Traditional Chinese (Taiwan)". I think we can add a marker in the future if traditional Chinese translations from other regions are added.