### PR TITLE
Dynamic aspect ratio change in full screen

### DIFF
--- a/src/hook.cpp
+++ b/src/hook.cpp
@@ -1366,6 +1366,20 @@ namespace
 		bool need_fullscreen = false;
 		auto screen_ratio = r.width / static_cast<double>(r.height);
 
+		if (g_auto_fullscreen)
+		{
+			float aspect_ratio = g_aspect_ratio;
+
+			if (!is_virt() && r.width > r.height)
+				aspect_ratio = static_cast<float>(r.width) / r.height;
+			else if (is_virt() && r.width < r.height)
+				aspect_ratio = static_cast<float>(r.height) / r.width;
+			else
+				aspect_ratio = orig_aspect_ratio;
+
+			g_aspect_ratio = aspect_ratio;
+		}
+
 		if (is_virt() && abs(screen_ratio - (1.f / g_aspect_ratio)) <= 0.001 && g_auto_fullscreen)
 			need_fullscreen = true;
 		else if (!is_virt() && abs(screen_ratio - g_aspect_ratio) <= 0.001 && g_auto_fullscreen)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -25,6 +25,7 @@ int g_max_fps = -1;
 bool g_unlock_size = false;
 float g_ui_scale = 1.0f;
 float g_aspect_ratio = 16.f / 9.f;
+float orig_aspect_ratio = g_aspect_ratio;
 // std::string g_extra_assetbundle_path;
 std::list<std::string> g_extra_assetbundle_paths{};
 std::variant<UseOriginalFont, UseDefaultFont, UseCustomFont> g_replace_font;
@@ -596,6 +597,8 @@ namespace
 					}
 				}
 			}
+
+			orig_aspect_ratio = g_aspect_ratio;
 
 			UmaCamera::initCameraSettings();
 

--- a/src/stdinclude.hpp
+++ b/src/stdinclude.hpp
@@ -55,6 +55,8 @@ extern float g_ui_scale;
 extern float g_aspect_ratio;
 extern bool g_read_request_pack;
 
+extern float orig_aspect_ratio;
+
 // extern std::string g_extra_assetbundle_path;
 extern std::list<std::string> g_extra_assetbundle_paths;
 


### PR DESCRIPTION
This change allows the screen aspect ratio to dynamically change and become full screen when the full screen setting is turned on and the game's screen orientation is the same as the display orientation.

For example, if you are using a 16:9 landscape display and the game aspect ratio is set to 16:15, the game will be set to 16:15 in portrait mode and will automatically change to 16:9 in landscape mode, allowing the game to go full screen. The aspect ratio is automatically restored when the screen is returned to portrait mode.

This is useful for players who prefer to always play on a wider screen.

![image](https://user-images.githubusercontent.com/90076182/229359808-55449be2-e898-4b9d-b113-b7132c92fd71.png)
