### PR TITLE
增加 训练场景 第一人称支持

### DIFF
--- a/resources/config.json
+++ b/resources/config.json
@@ -3,6 +3,7 @@
     "enableLogger": false,
     "dumpStaticEntries": false,
     "maxFps": 60,
+    "better60FPS": false,
     "highQuality": true,
     "enableVSync": false,
     "unlockSize": true,

--- a/resources/config.schema.json
+++ b/resources/config.schema.json
@@ -20,6 +20,11 @@
             "type": "integer",
             "minimum": -1
         },
+        "better60FPS": {
+            "description": "启用60帧优化",
+            "type": "boolean",
+            "default": false
+        },
         "highQuality": {
             "description": "高画质模式 (抗锯齿 MSAA x8, 锁定图形质量等级到最高)",
             "type": "boolean"

--- a/resources/config_en.schema.json
+++ b/resources/config_en.schema.json
@@ -20,6 +20,11 @@
             "type": "integer",
             "minimum": -1
         },
+        "better60FPS": {
+            "description": "60 Fps optimization",
+            "type": "boolean",
+            "default": false
+        },
         "highQuality": {
             "description": "High quality mode (FullQuality, MSAA x8)",
             "type": "boolean"

--- a/resources/config_zh_tw.schema.json
+++ b/resources/config_zh_tw.schema.json
@@ -20,6 +20,11 @@
             "type": "integer",
             "minimum": -1
         },
+        "better60FPS": {
+            "description": "開啟60幀優化",
+            "type": "boolean",
+            "default": false
+        },
         "highQuality": {
             "description": "高畫質模式 (抗鋸齒 MSAA x8, 鎖定圖形品質等級到最高)",
             "type": "boolean"

--- a/src/camera/camera.cpp
+++ b/src/camera/camera.cpp
@@ -354,6 +354,7 @@ namespace UmaCamera {
 		bool mouseLockThreadStart = false;
 		bool lookVertRunning, lookHoriRunning = false;
 		bool rMousePressFlg = false;
+		int cutIn_target_index = 0;
 
 		typedef struct Point
 		{
@@ -582,6 +583,10 @@ namespace UmaCamera {
 
 	Vector3_t getCameraLookat() {
 		return cameraLookAt;
+	}
+
+	int get_cutIn_target_index() {
+		return cutIn_target_index;
 	}
 
 	void set_lon_move(float vertangle, LonMoveHState moveState=LonMoveLeftAndRight) {  // «∞∫Û“∆∂Ø
@@ -936,7 +941,7 @@ namespace UmaCamera {
 		else {
 			preStep = moveStep / smoothLevel;
 		}
-
+		
 		homeCameraPos.y += moveStep;
 		for (int i = 0; i < smoothLevel; i++) {
 			cameraPos.y += preStep;
@@ -1046,6 +1051,12 @@ namespace UmaCamera {
 				printf("Look at No.%d\n", g_race_freecam_follow_umamusume_index + 1);
 			}
 		}
+		if (cameraType == CAMERA_CUTIN) {
+			if (cutIn_target_index > 0) {
+				cutIn_target_index--;
+			}
+			printf("Look at index (CutIn): %d\n", cutIn_target_index);
+		}
 	}
 
 	void singleRightClick() {
@@ -1053,12 +1064,23 @@ namespace UmaCamera {
 			g_race_freecam_follow_umamusume_index++;
 			printf("Look at No.%d\n", g_race_freecam_follow_umamusume_index + 1);
 		}
+		if (cameraType == CAMERA_CUTIN) {
+			cutIn_target_index++;
+			if (cutIn_target_index > 16) {
+				cutIn_target_index = 0;
+			}
+			printf("Look at index (CutIn): %d\n", cutIn_target_index);
+		}
 	}
 
 	void changeCameraFOV(float value) {
 		if (cameraType == CAMERA_RACE) {
 			raceDefaultFOV += value;
 			printf("Race camera FOV has been changed to %f\n", raceDefaultFOV);
+		}
+		else if (cameraType == CAMERA_CUTIN) {
+			liveDefaultFOV += value;
+			printf("Camera FOV has been changed to %f\n", liveDefaultFOV);
 		}
 		else {
 			if (!isLiveStart) return;
@@ -1095,6 +1117,10 @@ namespace UmaCamera {
 				liveCameraType = LiveCamera_FREE;
 				printf("LIVE Free Camera\n");
 			}
+		}
+		else if (cameraType == CAMERA_CUTIN) {
+			g_cutin_first_persion = !g_cutin_first_persion;
+			printf("CutIn camera first person %s.\n", g_cutin_first_persion ? "enabled" : "disabled");
 		}
 
 	}

--- a/src/camera/camera.hpp
+++ b/src/camera/camera.hpp
@@ -23,6 +23,7 @@ namespace UmaCamera {
 	int GetLiveCameraCharaParts();
 	int GetLiveCharaPositionIndex();
 	int GetLiveCameraType();
+	int get_cutIn_target_index();
 
 	void setRaceCamFOV(float value);
 	float getRaceCamFov();

--- a/src/hook.cpp
+++ b/src/hook.cpp
@@ -2285,6 +2285,22 @@ namespace
 		reinterpret_cast<decltype(CySpring_CreateBone_hook)*>(CySpring_CreateBone_orig)(_this, boneList, element, legacyScale, windPhaseShift, isAdd);
 	}
 
+	void* CySpringController_UpdateSpringThread_orig;
+	void CySpringController_UpdateSpringThread_hook(void* _this) {
+		if (g_enable_better60fps) {
+			static auto klass = il2cpp_symbols::get_class_from_instance(_this);
+			static auto set_UpdateMode = il2cpp_class_get_method_from_name(klass, "set_UpdateMode", 1);
+			if (set_UpdateMode) {
+				reinterpret_cast<void(*)(void*, int)>(set_UpdateMode->methodPointer)(_this, 1);
+			}
+			else {
+				static FieldInfo* updateModeField = il2cpp_class_get_field_from_name(klass, "<UpdateMode>k__BackingField");
+				il2cpp_symbols::write_field(_this, updateModeField, 1);
+			}
+		}
+		reinterpret_cast<decltype(CySpringController_UpdateSpringThread_hook)*>(CySpringController_UpdateSpringThread_orig)(_this);
+	}
+
 
 	int(*HorseData_get_GateNo)(void*);
 	float(*get_RunMotionRate)(void*);
@@ -4037,6 +4053,11 @@ namespace
 			"CySpring", "CreateBone", 5
 		);
 
+		auto CySpringController_UpdateSpringThread_addr = il2cpp_symbols::get_method_pointer(
+			"umamusume.dll", "Gallop",
+			"CySpringController", "UpdateSpringThread", 0
+		);
+
 		auto get_RunMotionSpeed_addr = il2cpp_symbols::get_method_pointer(
 			"umamusume.dll", "Gallop",
 			"HorseRaceInfoReplay", "get_RunMotionSpeed", 0
@@ -4408,6 +4429,7 @@ namespace
 		ADD_HOOK(GetCharacterWorldPos, "GetCharacterWorldPos at %p\n");
 		ADD_HOOK(Director_AlterUpdate, "Director_AlterUpdate at %p\n");
 		ADD_HOOK(CySpring_CreateBone, "CySpring_CreateBone at %p\n");
+		ADD_HOOK(CySpringController_UpdateSpringThread, "CySpringController_UpdateSpringThread at %p\n");
 		ADD_HOOK(get_RunMotionSpeed, "get_RunMotionSpeed at %p\n");
 		ADD_HOOK(HorseRaceInfoReplay_ctor, "HorseRaceInfoReplay_ctor at %p\n");
 		ADD_HOOK(AddUsedSkillId, "AddUsedSkillId at %p\n");

--- a/src/hook.cpp
+++ b/src/hook.cpp
@@ -1566,8 +1566,17 @@ namespace
 	}
 
 	void* get_camera_pos_orig;
-	Vector3_t* get_camera_pos_hook(void* _this, Il2CppObject* timelineControl) {
-		auto pos = reinterpret_cast<decltype(get_camera_pos_hook)*>(get_camera_pos_orig)(_this, timelineControl);
+	Vector3_t* get_camera_pos_hook(void* retstr, void* _this, Il2CppObject* timelineControl) {
+		const bool isFollowUma = (UmaCamera::GetLiveCameraType() == LiveCamera_FOLLOW_UMA) && g_live_free_camera;
+		if (isFollowUma) {
+			static auto klass = il2cpp_symbols::get_class_from_instance(_this);
+			static FieldInfo* setType_field = il2cpp_class_get_field_from_name(klass, "setType");
+			if (il2cpp_symbols::read_field<int>(_this, setType_field) != 1) {
+				il2cpp_symbols::write_field(_this, setType_field, 1);
+			}
+		}
+
+		auto pos = reinterpret_cast<decltype(get_camera_pos_hook)*>(get_camera_pos_orig)(retstr, _this, timelineControl);
 		if (!g_live_free_camera) {
 			return pos;
 		}
@@ -1886,7 +1895,7 @@ namespace
 	}
 
 	void* get_camera_pos2_orig;  // 暂时没用
-	Vector3_t* get_camera_pos2_hook(void* _this, Il2CppObject* timelineControl, void* type) {
+	Vector3_t* get_camera_pos2_hook(void* _this, Il2CppObject* timelineControl, int type) {
 		auto pos = reinterpret_cast<decltype(get_camera_pos2_hook)*>(get_camera_pos2_orig)(_this, timelineControl, type);
 		printf("pos2: %f, %f, %f\n", pos->x, pos->y, pos->z);
 		if (!g_live_free_camera) {
@@ -1901,7 +1910,7 @@ namespace
 	}
 
 	void* GetCharacterWorldPos_orig;
-	Vector3_t* GetCharacterWorldPos_hook(void* _this, void* timelineControl, int posFlag, int charaParts, Vector3_t* charaPos, Vector3_t* offset) {
+	Vector3_t* GetCharacterWorldPos_hook(void* retstr, void* timelineControl, int posFlag, int charaParts, Vector3_t* charaPos, Vector3_t* offset) {
 		const bool isFollowUma = (UmaCamera::GetLiveCameraType() == LiveCamera_FOLLOW_UMA) && g_live_free_camera;
 
 		if (isFollowUma) {
@@ -1915,7 +1924,7 @@ namespace
 			charaPos->z = 0;
 		}
 
-		auto ret = reinterpret_cast<decltype(GetCharacterWorldPos_hook)*>(GetCharacterWorldPos_orig)(_this, timelineControl, posFlag, charaParts, charaPos, offset);
+		auto ret = reinterpret_cast<decltype(GetCharacterWorldPos_hook)*>(GetCharacterWorldPos_orig)(retstr, timelineControl, posFlag, charaParts, charaPos, offset);
 		
 		if (isFollowUma) {
 			// printf("GetCharacterWorldPos: %d (%f, %f, %f)\n", posFlag, ret->x, ret->y, ret->z);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -93,6 +93,7 @@ std::list<std::function<void(void)>> onPluginReload{};
 bool enableRaceInfoTab = false;
 bool raceInfoTabAttachToGame = false;
 bool g_enable_live_dof_controller = false;
+bool g_enable_better60fps = false;
 
 constexpr const char LocalizedDataPath[] = "localized_data";
 constexpr const char OldLocalizedDataPath[] = "old_localized_data";
@@ -435,6 +436,10 @@ namespace
 			g_max_fps = document["maxFps"].GetInt();
 			g_unlock_size = document["unlockSize"].GetBool();
 			g_ui_scale = document["uiScale"].GetFloat();
+
+			if (document.HasMember("better60FPS")) {
+				g_enable_better60fps = document["better60FPS"].GetBool();
+			}
 
 			if (document.HasMember("readRequestPack")) {
 				g_read_request_pack = document["readRequestPack"].GetBool();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -83,6 +83,8 @@ std::wstring g_convert_url;
 bool g_enable_self_server = false;
 std::wstring g_self_server_url;
 
+bool g_cutin_first_persion = false;
+
 std::string g_text_data_dict_path;
 std::string g_character_system_text_dict_path;
 std::string g_race_jikkyo_comment_dict_path;

--- a/src/stdinclude.hpp
+++ b/src/stdinclude.hpp
@@ -187,3 +187,4 @@ extern std::string dumpGameAssemblyPath;
 extern bool g_enable_live_dof_controller;
 extern bool guiStarting;
 extern bool g_cutin_first_persion;
+extern bool g_enable_better60fps;

--- a/src/stdinclude.hpp
+++ b/src/stdinclude.hpp
@@ -75,7 +75,8 @@ struct UseCustomFont
 
 enum CameraType {
 	CAMERA_LIVE = 0,
-	CAMERA_RACE = 1
+	CAMERA_RACE = 1,
+	CAMERA_CUTIN = 2
 };
 
 enum LiveCameraType {
@@ -185,3 +186,4 @@ extern bool g_force_landscape;
 extern std::string dumpGameAssemblyPath;
 extern bool g_enable_live_dof_controller;
 extern bool guiStarting;
+extern bool g_cutin_first_persion;

--- a/src/umagui/guiShowData.cpp
+++ b/src/umagui/guiShowData.cpp
@@ -47,6 +47,9 @@ std::vector<int32_t>{ 0x1, 0x2, 0x4, 0x8, 0x10, 0x20, 0x40, 0x80, 0x100, 0x200, 
 }
 );
 
+std::list<UmaGUiShowData::UmaBoneData> UmaGUiShowData::umaBoneData{ UmaGUiShowData::UmaBoneData{ ".*Bust.*" }};
+bool UmaGUiShowData::isEnableUmaBone = false;
+
 UmaGUiShowData::UmaRaceMotionData::UmaRaceMotionData(int gateNo, std::wstring charaName, std::wstring trainerName) {
 	this->gateNo = gateNo;
 	this->charaName = utility::conversions::to_utf8string(charaName);

--- a/src/umagui/guiShowData.hpp
+++ b/src/umagui/guiShowData.hpp
@@ -372,6 +372,37 @@ namespace UmaGUiShowData {
 		bool followGame = true;
 	};
 
+	struct UmaBoneData {
+		std::string reg = "";
+		bool enabled = true;
+
+		float stiffnessForce = 550.0f;
+		float dragForce = 480.0f;
+		float gravity = 100.0f;
+
+		float collisionRadius = 0.01f;
+		bool needEnvCollision = false;
+		float verticalWindRateSlow = 0;
+		float horizontalWindRateSlow = 0;
+		float verticalWindRateFast = 0;
+		float horizontalWindRateFast = 0;
+		bool isLimit = true;
+		float MoveSpringApplyRate = 0.8f;
+
+		bool replace_stiffnessForce = false;
+		bool replace_dragForce = false;
+		bool replace_gravity = false;
+		bool replace_collisionRadius = false;
+		bool replace_needEnvCollision = false;
+		bool replace_verticalWindRateSlow = false;
+		bool replace_horizontalWindRateSlow = false;
+		bool replace_verticalWindRateFast = false;
+		bool replace_horizontalWindRateFast = false;
+		bool replace_isLimit = false;
+		bool replace_MoveSpringApplyRate = false;
+
+	};
+
 
 	// PostEffectUpdateInfo_DOF
 	extern Vector3_t liveDOFForcalPosition;
@@ -415,6 +446,8 @@ namespace UmaGUiShowData {
 	extern std::unordered_map<int, GlobalLightUpdateInfo> globalLightUpdateInfo;
 	extern bool globalLightUpdateInfo_inited;
 
+	extern std::list<UmaGUiShowData::UmaBoneData> umaBoneData;
+	extern bool isEnableUmaBone;
 
 	void initGuiGlobalData();
 }

--- a/src/umagui/liveGUI.cpp
+++ b/src/umagui/liveGUI.cpp
@@ -293,18 +293,75 @@ namespace LiveGUILoops {
         if (!showLiveWnd) return;
 
         if (ImGui::Begin("Live Other Settings")) {
-            if (ImGui::CollapsingHeader("Exposure")) {
+            if (ImGui::CollapsingHeader("Exposure", ImGuiTreeNodeFlags_DefaultOpen)) {
                 ImGui::Checkbox("Use Game Exposure Settings", &liveExposureFollowGame);
                 ImGui::Checkbox("IsEnable Exposure", &exposureUpdateInfo.IsEnable);
                 ImGui::InputFloat4("ExposureParameter", &exposureUpdateInfo.ExposureParameter.x);
                 INPUT_AND_SLIDER_FLOAT("DepthMask", &exposureUpdateInfo.DepthMask, -3.5f, 7.0f);
             }
-            if (ImGui::CollapsingHeader("Vortex")) {
+            if (ImGui::CollapsingHeader("Vortex", ImGuiTreeNodeFlags_DefaultOpen)) {
                 ImGui::Checkbox("Use Game Vortex Settings", &liveVortexFollowGame);
                 ImGui::Checkbox("IsEnable Vortex", &vortexUpdateInfo.IsEnable);
                 INPUT_AND_SLIDER_FLOAT("RotVolume", &vortexUpdateInfo.RotVolume, -10.0f, 10.0f);
                 INPUT_AND_SLIDER_FLOAT("DepthClip", &vortexUpdateInfo.DepthClip, -10.0f, 10.0f);
                 ImGui::InputFloat4("Area", &vortexUpdateInfo.Area.x);
+            }
+        }
+        ImGui::End();
+    }
+
+    void umaBoneLoop() {
+#define CHECKBOX_AND_INPUT_AND_SLIDER_FLOAT(label, data, min, max)\
+    ImGui::Checkbox("Emit##check_"###label, &it->replace_##label);\
+    ImGui::SameLine();INPUT_AND_SLIDER_FLOAT(#label, data, min, max)
+
+        if (!showLiveWnd) return;
+        if (ImGui::Begin("Uma Bone Settings")) {
+            ImGui::Checkbox("Enable self bone settings (Non-real-time, requires reload model.)", &isEnableUmaBone);
+            if (ImGui::Button("Add")) {
+                umaBoneData.emplace_back(UmaBoneData{});
+            }
+
+            int forCount = 0;
+            for (auto it = umaBoneData.begin(); it != umaBoneData.end();) {
+                ImGui::PushID(std::format("boneForCount{}", forCount).c_str());
+                auto isRemove = false;
+
+                if (ImGui::CollapsingHeader(std::format("Set{}", forCount).c_str(), ImGuiTreeNodeFlags_DefaultOpen)) {
+                    char buf[256];
+                    strcpy_s(buf, it->reg.c_str());
+                    ImGui::InputText("Regex", buf, 256);
+                    it->reg = buf;
+                    ImGui::SameLine();
+                    isRemove = ImGui::Button("Delete");
+
+                    ImGui::Checkbox("Enable this settings", &it->enabled);
+                    CHECKBOX_AND_INPUT_AND_SLIDER_FLOAT(stiffnessForce, &it->stiffnessForce, -100.0f, 1500.0f);
+                    CHECKBOX_AND_INPUT_AND_SLIDER_FLOAT(dragForce, &it->dragForce, -100.0f, 1500.0f);
+                    CHECKBOX_AND_INPUT_AND_SLIDER_FLOAT(gravity, &it->gravity, -100.0f, 1500.0f);
+                    CHECKBOX_AND_INPUT_AND_SLIDER_FLOAT(collisionRadius, &it->collisionRadius, -1.0f, 1.0f);
+                    ImGui::Checkbox("Emit##check_needEnvCollision", &it->replace_needEnvCollision);
+                    ImGui::SameLine();
+                    ImGui::Checkbox("isLimit", &it->needEnvCollision);
+                    CHECKBOX_AND_INPUT_AND_SLIDER_FLOAT(verticalWindRateSlow, &it->verticalWindRateSlow, -1.0f, 1.0f);
+                    CHECKBOX_AND_INPUT_AND_SLIDER_FLOAT(horizontalWindRateSlow, &it->horizontalWindRateSlow, -1.0f, 1.0f);
+                    CHECKBOX_AND_INPUT_AND_SLIDER_FLOAT(verticalWindRateFast, &it->verticalWindRateFast, -1.0f, 1.0f);
+                    CHECKBOX_AND_INPUT_AND_SLIDER_FLOAT(horizontalWindRateFast, &it->horizontalWindRateFast, -1.0f, 1.0f);
+                    ImGui::Checkbox("Emit##check_isLimit", &it->replace_isLimit);
+                    ImGui::SameLine();
+                    ImGui::Checkbox("isLimit", &it->isLimit);
+                    CHECKBOX_AND_INPUT_AND_SLIDER_FLOAT(MoveSpringApplyRate, &it->MoveSpringApplyRate, -5.0f, 5.0f);
+
+                }
+                ImGui::PopID();
+
+                if (isRemove) {
+                    it = umaBoneData.erase(it);
+                }
+                else {
+                    it++;
+                }
+                forCount++;
             }
         }
         ImGui::End();
@@ -317,6 +374,7 @@ namespace LiveGUILoops {
         static bool lightProjection = false;
         static bool radialBlur = false;
         static bool charaFootLight = false;
+        static bool charaBone = false;
         static bool globalLight = false;
 
         if (!showLiveWnd) return;
@@ -329,6 +387,7 @@ namespace LiveGUILoops {
             ImGui::Checkbox("PostFilm", &postFilm);
             ImGui::Checkbox("LightProjection", &lightProjection);
             ImGui::Checkbox("CharaFootLight", &charaFootLight);
+            ImGui::Checkbox("CharaBone", &charaBone);
         }
         ImGui::End();
 
@@ -339,6 +398,7 @@ namespace LiveGUILoops {
         if (charaFootLight) charaFootLightMainLoop();
         if (globalLight) globalLightMainLoop();
         if (others) othersMainLoop();
+        if (charaBone) umaBoneLoop();
     }
 
 }

--- a/src/umagui/liveGUI.cpp
+++ b/src/umagui/liveGUI.cpp
@@ -342,7 +342,7 @@ namespace LiveGUILoops {
                     CHECKBOX_AND_INPUT_AND_SLIDER_FLOAT(collisionRadius, &it->collisionRadius, -1.0f, 1.0f);
                     ImGui::Checkbox("Emit##check_needEnvCollision", &it->replace_needEnvCollision);
                     ImGui::SameLine();
-                    ImGui::Checkbox("isLimit", &it->needEnvCollision);
+                    ImGui::Checkbox("needEnvCollision", &it->needEnvCollision);
                     CHECKBOX_AND_INPUT_AND_SLIDER_FLOAT(verticalWindRateSlow, &it->verticalWindRateSlow, -1.0f, 1.0f);
                     CHECKBOX_AND_INPUT_AND_SLIDER_FLOAT(horizontalWindRateSlow, &it->horizontalWindRateSlow, -1.0f, 1.0f);
                     CHECKBOX_AND_INPUT_AND_SLIDER_FLOAT(verticalWindRateFast, &it->verticalWindRateFast, -1.0f, 1.0f);

--- a/src/umagui/liveGUI.cpp
+++ b/src/umagui/liveGUI.cpp
@@ -387,7 +387,7 @@ namespace LiveGUILoops {
             ImGui::Checkbox("PostFilm", &postFilm);
             ImGui::Checkbox("LightProjection", &lightProjection);
             ImGui::Checkbox("CharaFootLight", &charaFootLight);
-            ImGui::Checkbox("CharaBone", &charaBone);
+            ImGui::Checkbox("Chara Bone (Global)", &charaBone);
         }
         ImGui::End();
 


### PR DESCRIPTION
 - 增加 `CutIn` 场景 第一人称支持 （训练、技能、抽卡、登场动画等）
 - Live 跟随角色模式不需要在外部插件修改 AB 包了，以前修改过的可以在外部插件里面还原 (`Restore`)
 - 支持启动外部插件时修改窗口参数 (在窗口设置栏内添加名为 `OnLoad` 的配置项即可) #136 
 - 增加角色骨骼参数调整功能（Live参数设置窗口内）~~可以调整欧派抖动幅度了~~
 - 增加 60 帧优化功能 (渲染时会启用游戏内置的 60FPSMode，可以加强部分因提高帧率而丢失的物理效果)