### PR TITLE
支持 Sprite Texture、本地 png 替换

### DIFF
--- a/resources/config.json
+++ b/resources/config.json
@@ -24,6 +24,7 @@
     "customFontStyle": 0,
     "customFontLinespacing": 0.6,
     "replaceAssets": true,
+    "dumpSpriteTexture": false,
     "assetLoadLog": false,
     "live": {
         "free_camera": false,

--- a/resources/config.json
+++ b/resources/config.json
@@ -25,6 +25,7 @@
     "customFontLinespacing": 0.6,
     "replaceAssets": true,
     "dumpSpriteTexture": false,
+    "dumpRuntimeTexture": false,
     "assetLoadLog": false,
     "live": {
         "free_camera": false,

--- a/resources/config.schema.json
+++ b/resources/config.schema.json
@@ -116,6 +116,11 @@
             "description": "是否开启图片等资源替换",
             "type": "boolean"
         },
+        "dumpSpriteTexture": {
+            "description": "Dump Sprite 图像资源",
+            "type": "boolean",
+            "default": false
+        },
         "assetLoadLog": {
             "description": "是否在debug输出游戏资源调用情况",
             "type": "boolean"

--- a/resources/config.schema.json
+++ b/resources/config.schema.json
@@ -121,6 +121,11 @@
             "type": "boolean",
             "default": false
         },
+        "dumpRuntimeTexture": {
+            "description": "Dump Runtime 图像资源",
+            "type": "boolean",
+            "default": false
+        },
         "assetLoadLog": {
             "description": "是否在debug输出游戏资源调用情况",
             "type": "boolean"

--- a/resources/config_en.schema.json
+++ b/resources/config_en.schema.json
@@ -116,6 +116,11 @@
             "description": "Replacing the game picture/texture with resource in extraAssetBundlePath if exist",
             "type": "boolean"
         },
+        "dumpSpriteTexture": {
+            "description": "Dump Sprite Texture",
+            "type": "boolean",
+            "default": false
+        },
         "assetLoadLog": {
             "description": "Print the asset bundle path of game resource that the game is using",
             "type": "boolean"

--- a/resources/config_en.schema.json
+++ b/resources/config_en.schema.json
@@ -121,6 +121,11 @@
             "type": "boolean",
             "default": false
         },
+        "dumpRuntimeTexture": {
+            "description": "Dump Runtime Texture",
+            "type": "boolean",
+            "default": false
+        },
         "assetLoadLog": {
             "description": "Print the asset bundle path of game resource that the game is using",
             "type": "boolean"

--- a/resources/config_ja.schema.json
+++ b/resources/config_ja.schema.json
@@ -121,6 +121,11 @@
             "type": "boolean",
             "default": false
         },
+        "dumpRuntimeTexture": {
+            "description": "Dump Runtime Texture",
+            "type": "boolean",
+            "default": false
+        },
         "assetLoadLog": {
             "description": "デバッグ時にゲームリソースの呼び出し状況を出力します。",
             "type": "boolean"

--- a/resources/config_ja.schema.json
+++ b/resources/config_ja.schema.json
@@ -116,6 +116,11 @@
             "description": "画像やその他のリソースの置換を有効化します。",
             "type": "boolean"
         },
+        "dumpSpriteTexture": {
+            "description": "Dump Sprite Texture",
+            "type": "boolean",
+            "default": false
+        },
         "assetLoadLog": {
             "description": "デバッグ時にゲームリソースの呼び出し状況を出力します。",
             "type": "boolean"

--- a/resources/config_zh_tw.schema.json
+++ b/resources/config_zh_tw.schema.json
@@ -121,6 +121,11 @@
             "type": "boolean",
             "default": false
         },
+        "dumpRuntimeTexture": {
+            "description": "Dump Runtime 素材",
+            "type": "boolean",
+            "default": false
+        },
         "assetLoadLog": {
             "description": "是否在debug輸出遊戲素材調用情況",
             "type": "boolean"

--- a/resources/config_zh_tw.schema.json
+++ b/resources/config_zh_tw.schema.json
@@ -116,6 +116,11 @@
             "description": "是否開啟圖片等素材替換",
             "type": "boolean"
         },
+        "dumpSpriteTexture": {
+            "description": "Dump Sprite 素材",
+            "type": "boolean",
+            "default": false
+        },
         "assetLoadLog": {
             "description": "是否在debug輸出遊戲素材調用情況",
             "type": "boolean"

--- a/src/hook.cpp
+++ b/src/hook.cpp
@@ -1461,7 +1461,7 @@ namespace
 		auto texture2D = reinterpret_cast<decltype(Sprite_get_texture_hook)*>(Sprite_get_texture_orig)(_this);
 		if (g_replace_assets) {
 			auto object_name = get_ObjectName(texture2D);
-			static std::filesystem::path baseSearchPath = "localized_data/res";
+			static std::filesystem::path baseSearchPath = "localized_data/res/texture2d";
 
 			if (object_name) {
 				const std::wstring objName(object_name->start_char);

--- a/src/il2cpp/il2cpp_symbols.hpp
+++ b/src/il2cpp/il2cpp_symbols.hpp
@@ -244,6 +244,36 @@ typedef struct Il2CppArraySize
 	void* vector[0];
 } Il2CppArraySize;
 
+typedef struct Il2CppException
+{
+	Il2CppObject object;
+	Il2CppString* className;
+	Il2CppString* message;
+	Il2CppObject* _data;
+	Il2CppException* inner_ex;
+	Il2CppString* _helpURL;
+	Il2CppArraySize* trace_ips;
+	Il2CppString* stack_trace;
+	Il2CppString* remote_stack_trace;
+	int remote_stack_index;
+	Il2CppObject* _dynamicMethods;
+	int32_t hresult;
+	Il2CppString* source;
+	Il2CppObject* safeSerializationManager;
+	Il2CppArraySize* captured_traces;
+	Il2CppArraySize* native_trace_ips;
+} Il2CppException;
+
+template<typename T>
+struct Il2CppArraySize_t
+{
+	Il2CppObject obj;
+	void* bounds;
+	uintptr_t max_length;
+	alignas(8)
+		T vector[0];
+};
+
 struct Il2CppClassHead
 {
 	const void* image;
@@ -256,6 +286,15 @@ struct Il2CppReflectionType
 {
 	Il2CppObject object;
 	const Il2CppType* type;
+};
+
+struct Rect_t
+{
+public:
+	float x;
+	float y;
+	float width;
+	float height;
 };
 
 static const size_t kIl2CppSizeOfArray = (offsetof(Il2CppArraySize, vector));

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -90,6 +90,7 @@ std::wstring g_self_server_url;
 
 bool g_enable_cutin_first_person = false;
 bool g_cutin_first_person = false;
+bool g_dump_sprite_tex = false;
 
 std::string g_text_data_dict_path;
 std::string g_character_system_text_dict_path;
@@ -745,6 +746,10 @@ namespace
 			if (document.HasMember("raceInfoTab")) {
 				enableRaceInfoTab = document["raceInfoTab"]["enableRaceInfoTab"].GetBool();
 				raceInfoTabAttachToGame = document["raceInfoTab"]["raceInfoTabAttachToGame"].GetBool();
+			}
+
+			if (document.HasMember("dumpSpriteTexture")) {
+				g_dump_sprite_tex = document["dumpSpriteTexture"].GetBool();
 			}
 
 			// Looks like not working for now

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -91,6 +91,7 @@ std::wstring g_self_server_url;
 bool g_enable_cutin_first_person = false;
 bool g_cutin_first_person = false;
 bool g_dump_sprite_tex = false;
+bool g_dump_bundle_tex = false;
 
 std::string g_text_data_dict_path;
 std::string g_character_system_text_dict_path;
@@ -750,6 +751,9 @@ namespace
 
 			if (document.HasMember("dumpSpriteTexture")) {
 				g_dump_sprite_tex = document["dumpSpriteTexture"].GetBool();
+			}
+			if (document.HasMember("dumpRuntimeTexture")) {
+				g_dump_bundle_tex = document["dumpRuntimeTexture"].GetBool();
 			}
 
 			// Looks like not working for now

--- a/src/stdinclude.hpp
+++ b/src/stdinclude.hpp
@@ -199,3 +199,4 @@ extern std::string g_custom_PersistentDataPath;
 extern bool g_upload_gacha_history;
 extern std::wstring g_upload_gacha_history_endpoint;
 extern bool g_dump_sprite_tex;
+extern bool g_dump_bundle_tex;

--- a/src/stdinclude.hpp
+++ b/src/stdinclude.hpp
@@ -198,3 +198,4 @@ extern bool g_enable_custom_PersistentDataPath;
 extern std::string g_custom_PersistentDataPath;
 extern bool g_upload_gacha_history;
 extern std::wstring g_upload_gacha_history_endpoint;
+extern bool g_dump_sprite_tex;


### PR DESCRIPTION
Sprite 根据资源名 + 本地文件替换
Sprite 文件位置于: `localized_data/res/texture2d` 内，要求格式为 `png`
Bundle 文件位置于 `localized_data/res/texture2d/fromBundle` 内，子目录路径和 bundle path 一致