### PR TITLE
Fix return type of PreparedQuery_BindInt_hook

### DIFF
--- a/src/hook.cpp
+++ b/src/hook.cpp
@@ -514,7 +514,7 @@ namespace
 	}
 
 	void* PreparedQuery_BindInt_orig = nullptr;
-	void PreparedQuery_BindInt_hook(void* _this, int32_t idx, int32_t value)
+	bool PreparedQuery_BindInt_hook(void* _this, int32_t idx, int32_t value)
 	{
 		if (const auto iter = text_queries.find(_this); iter != text_queries.end())
 		{


### PR DESCRIPTION
The return type of PreparedQuery::BindInt is `bool`, not `void`.

Fixes a rare bug where the loading process would get stuck at 60%.